### PR TITLE
Require exactly nova v4.x for 2.x package version and Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@
 
 You can install the package in to a Laravel app that uses [Nova](https://nova.laravel.com) via composer:
 
+### For Nova v4
+
 ```bash
-composer require reedware/nova-text-filter
+composer require reedware/nova-text-filter:^2.0
+```
+
+### For Nova v3
+
+```bash
+composer require reedware/nova-text-filter:^1.0
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "laravel/nova": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
1. Update installation guide for both v4 and v3 laravel nova
2. Require `laravel/nova:^4.0` for 2.x package version